### PR TITLE
Refer to full object path for data_results_table

### DIFF
--- a/server-inputdata.R
+++ b/server-inputdata.R
@@ -76,7 +76,7 @@ inputDataReactive <- reactive({
   }else if(input$data_file_type=="previousrdata"){
     if (!is.null(inRFile)) {
       load(inRFile$datapath,envir=environment())
-      return(list("data"=data_results_table)) # this is so something shows in data upload window
+      return(list("data"=start_list$data_results_table)) # this is so something shows in data upload window
     }else{return(NULL)}
   }else { # if uploading data
     if (!is.null(inFile)) {


### PR DESCRIPTION
Fixes #12.

@jminnier , ready for review.

As described in #12 , I noticed that the `data_results_table` was actually saved as part of the `start_list` object when saving the RData file.

As I'm not that familiar with how the `save()` logic works in combination with `analyzeDataReactive()` in Shiny, I thought of correcting this during the RData file upload. Maybe it would be more proper to correct this while saving the RData file, however.

Similarly, I've briefly tested it on the test dataset and one of my files as well and the basic plots such as "Gene expression boxplots" seem to work.

Let me know if you'd like any additional test, information, or anything else.

Best,